### PR TITLE
feat: add RecordTime option to control slog record time logging

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -26,8 +26,6 @@ type Option struct {
 	// optional: see slog.HandlerOptions
 	AddSource   bool
 	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
-
-	RecordTime bool
 }
 
 func (o Option) NewZapHandler() slog.Handler {
@@ -83,9 +81,10 @@ func (h *ZapHandler) Handle(ctx context.Context, record slog.Record) error {
 			checked.Caller = zapcore.EntryCaller{}
 			checked.Stack = ""
 		}
-		if h.option.RecordTime {
-			checked.Time = record.Time
-		}
+
+		// use slog record time
+		checked.Time = record.Time
+
 		checked.Write(fields...)
 		return nil
 	} else {

--- a/handler.go
+++ b/handler.go
@@ -26,6 +26,8 @@ type Option struct {
 	// optional: see slog.HandlerOptions
 	AddSource   bool
 	ReplaceAttr func(groups []string, a slog.Attr) slog.Attr
+
+	RecordTime bool
 }
 
 func (o Option) NewZapHandler() slog.Handler {
@@ -80,6 +82,9 @@ func (h *ZapHandler) Handle(ctx context.Context, record slog.Record) error {
 		} else {
 			checked.Caller = zapcore.EntryCaller{}
 			checked.Stack = ""
+		}
+		if h.option.RecordTime {
+			checked.Time = record.Time
 		}
 		checked.Write(fields...)
 		return nil


### PR DESCRIPTION
## What does this PR do?
- Add a new `RecordTime` boolean option to the `Option` struct
- When enabled, the log handler uses the timestamp from `slog.Record` instead of Zap's auto-generated current time
- Keep backward compatibility: `RecordTime` defaults to `false` (original behavior unchanged)

## Why is this change needed?
- **Custom timestamp support**: For scenarios like log forwarding, delayed processing, event replay, or consistent timestamps across services
- **Explicit control**: Let users decide whether to use the original record time or system time
- **Non-breaking change**: No impact on existing users and integrations

## Usage example
```go
opt := handler.Option{
    RecordTime: true, // enable using slog.Record time
}
```
## Key changes
Add `RecordTime` bool to `Option` struct
Set `checked.Time = record.Time` in `Handle()` when `RecordTime = true`
Default value: `false` (preserve original behavior)